### PR TITLE
Improvements to GitHub bot comment

### DIFF
--- a/crates/github/src/changes.rs
+++ b/crates/github/src/changes.rs
@@ -162,6 +162,135 @@ fn measure_line_simple(name: &str, from: u64, to: u64) -> String {
     format!("**{name}**: {to} ({diff_str})\n")
 }
 
+const MAX_CHANGE_LINES: i32 = 30;
+
+#[derive(PartialEq, Eq)]
+enum ChangeKind {
+    NewMatch,
+    BrokenMatch,
+    Improvement,
+    Regression,
+}
+
+struct ChangeLine {
+    kind: ChangeKind,
+    unit_name: String,
+    item_name: String,
+    to_fuzzy_match_percent: f32,
+    bytes_diff: i64,
+}
+
+fn output_line(line: &ChangeLine, out: &mut String) {
+    let emoji = match line.kind {
+        ChangeKind::NewMatch => "✅",
+        ChangeKind::BrokenMatch => "💔",
+        ChangeKind::Improvement => "📈",
+        ChangeKind::Regression => "📉",
+    };
+
+    let bytes_str = match line.bytes_diff.cmp(&0) {
+        Ordering::Less => line.bytes_diff.to_string(),
+        Ordering::Equal => "0".to_string(),
+        Ordering::Greater => format!("+{}", line.bytes_diff),
+    };
+    out.push_str(&format!(
+        "{emoji} `{} | {}` {} bytes -> {:.2}%\n",
+        line.unit_name, line.item_name, bytes_str, line.to_fuzzy_match_percent
+    ));
+}
+
+fn truncate_num_displayed(shown_improvements: &mut usize, shown_regressions: &mut usize) {
+    loop {
+        let excess = (*shown_improvements + *shown_regressions) as i32 - MAX_CHANGE_LINES;
+        if excess <= 0 {
+            return;
+        }
+
+        let excess = excess as usize;
+
+        if shown_improvements == shown_regressions {
+            *shown_improvements -= excess / 2;
+            *shown_regressions -= excess / 2;
+            if excess % 2 != 0 {
+                *shown_regressions -= 1;
+            }
+            return;
+        }
+
+        if shown_improvements > shown_regressions {
+            *shown_improvements -= excess.min(*shown_improvements - *shown_regressions);
+        } else {
+            *shown_regressions -= excess.min(*shown_regressions - *shown_improvements);
+        }
+    }
+}
+
+fn generate_changes_list(changes: Vec<ChangeLine>, out: &mut String) {
+    let (mut improvements, mut regressions): (Vec<_>, Vec<_>) =
+        changes.into_iter().partition(|item| {
+            item.kind == ChangeKind::NewMatch || item.kind == ChangeKind::Improvement
+        });
+    // first show new matches, then other improvements, each sorted by amount improved
+    improvements.sort_by_key(|item| (item.kind != ChangeKind::NewMatch, -item.bytes_diff));
+    // first show broken matches, then regressions, each sorted by amount regressed
+    regressions.sort_by_key(|item| (item.kind != ChangeKind::BrokenMatch, item.bytes_diff));
+
+    let mut shown_improvements = improvements.len();
+    let mut shown_regressions = regressions.len();
+
+    truncate_num_displayed(&mut shown_improvements, &mut shown_regressions);
+
+    if !improvements.is_empty() {
+        let num_newly_matched =
+            improvements.iter().filter(|item| item.kind == ChangeKind::NewMatch).count();
+
+        if num_newly_matched == improvements.len() {
+            out.push_str(&format!("{} newly matched\n", num_newly_matched));
+        } else {
+            out.push_str(&format!(
+                "{} improvements ({} newly matched)\n",
+                improvements.len(),
+                num_newly_matched
+            ));
+        }
+
+        for line in improvements.iter().take(shown_improvements) {
+            output_line(line, out);
+        }
+
+        if shown_improvements < improvements.len() {
+            out.push_str(&format!(
+                "...and {} more improvements\n\n",
+                improvements.len() - shown_improvements
+            ));
+        }
+    }
+
+    if !regressions.is_empty() {
+        let num_broken_matches =
+            regressions.iter().filter(|item| item.kind == ChangeKind::BrokenMatch).count();
+
+        if num_broken_matches == regressions.len() {
+            out.push_str(&format!("{} no longer matching\n", num_broken_matches));
+        } else {
+            out.push_str(&format!(
+                "{} regressions ({} no longer matching)\n",
+                regressions.len(),
+                num_broken_matches
+            ));
+        }
+
+        for line in regressions.iter().take(shown_regressions) {
+            output_line(line, out);
+        }
+
+        out.push_str(&format!(
+            "...and {} more regressions\n\n",
+            regressions.len() - shown_regressions
+        ));
+    }
+}
+
 pub fn generate_comment(
     from: &Report,
     to: &Report,
@@ -218,11 +347,13 @@ pub fn generate_comment(
     if measure_written {
         comment.push('\n');
     }
-    let mut total_changes = 0;
     let mut iter = changes.units.into_iter().flat_map(|mut unit| {
         let functions = core::mem::take(&mut unit.functions);
         functions.into_iter().map(move |f| (unit.clone(), f))
     });
+
+    let mut changes = vec![];
+
     for (unit, item) in iter.by_ref() {
         let (from, to) = match (item.from, item.to) {
             (Some(from), Some(to)) => (from, to),
@@ -230,36 +361,34 @@ pub fn generate_comment(
             (Some(from), None) => (from, ChangeItemInfo::default()),
             (None, None) => continue,
         };
-        let emoji = if to.fuzzy_match_percent == 100.0 {
-            "✅"
+        let kind = if to.fuzzy_match_percent == 100.0 {
+            ChangeKind::NewMatch
+        } else if from.fuzzy_match_percent == 100.0 {
+            ChangeKind::BrokenMatch
         } else if to.fuzzy_match_percent > from.fuzzy_match_percent {
-            "📈"
+            ChangeKind::Improvement
         } else {
-            "📉"
+            ChangeKind::Regression
         };
         let from_bytes = ((from.fuzzy_match_percent as f64 / 100.0) * from.size as f64) as u64;
         let to_bytes = ((to.fuzzy_match_percent as f64 / 100.0) * to.size as f64) as u64;
         let bytes_diff = to_bytes as i64 - from_bytes as i64;
-        let bytes_str = match bytes_diff.cmp(&0) {
-            Ordering::Less => bytes_diff.to_string(),
-            Ordering::Equal => "0".to_string(),
-            Ordering::Greater => format!("+{}", bytes_diff),
-        };
         let name =
             item.metadata.as_ref().and_then(|m| m.demangled_name.as_deref()).unwrap_or(&item.name);
-        comment.push_str(&format!(
-            "{emoji} `{} | {}` {} bytes -> {:.2}%\n",
-            unit.name, name, bytes_str, to.fuzzy_match_percent
-        ));
-        total_changes += 1;
-        if total_changes >= 30 {
-            break;
-        }
+
+        let change = ChangeLine {
+            kind,
+            unit_name: unit.name.to_owned(),
+            item_name: name.to_owned(),
+            bytes_diff,
+            to_fuzzy_match_percent: to.fuzzy_match_percent,
+        };
+
+        changes.push(change);
     }
-    let remaining = iter.count();
-    if remaining > 0 {
-        comment.push_str(&format!("...and {} more items\n", remaining));
-    } else if total_changes == 0 {
+    if !changes.is_empty() {
+        generate_changes_list(changes, &mut comment);
+    } else {
         comment.push_str("No changes\n");
     }
     comment


### PR DESCRIPTION
Example output based on the report diff for https://github.com/zeldaret/ss/pull/117 below

Use cases:

* As a reader, I want more detailed numbers regarding the number of improvements and regressions
* As an author and reviewer, I want to be able to tell if there are any regressions and if so, how many, since they might be unintentional
* As an author and reviewer, I want to clearly see if a PR that has many expected small regressions breaks any previously 100% matched functions, since these might still be unintentional

### Report for unknown (<none> - <none>)

📈 **Matched code**: 16.19% (+0.03%, +3976 bytes)

87 improvements (35 newly matched)
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c_classInit()` +401 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::createHeap()` +356 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_6B10()` +268 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_4B50()` +256 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_6C20(bool)` +236 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_4200()` +188 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::~dAcEsm_c()` +160 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_44C0()` +120 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_5D0()` +112 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_4450()` +100 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dWaterEffect_c::~dWaterEffect_c()` +92 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dShadowCircle_c::~dShadowCircle_c()` +88 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::fn_187_4C50()` +88 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dScnCallback_c::~dScnCallback_c()` +64 bytes -> 100.00%
✅ `d_a_e_smNP/REL/d/a/e/d_a_e_sm | dAcEsm_c::SmData_c::~SmData_c()` +64 bytes -> 100.00%
...and 72 more improvements

50 regressions (8 no longer matching)
💔 `d_a_obj_tuboNP/REL/d/a/obj/d_a_obj_tubo | __sinit_\d_a_obj_tubo_cpp` -140 bytes -> 86.17%
💔 `d_a_obj_tuboNP/REL/d/a/obj/d_a_obj_tubo | dAcOtubo_c::attemptDestroyOnWall(unsigned long*, const unsigned char*)` -100 bytes -> 0.00%
💔 `d_a_obj_ivy_ropeNP/REL/d/a/obj/d_a_obj_ivy_rope | dAcOivyRope_c::fn_256_E3E0()` -80 bytes -> 91.45%
💔 `d_a_obj_dungeon_shipNP/REL/d/a/obj/d_a_obj_dungeon_ship | dAcODungeonShip_c::fn_485_1960()` -65 bytes -> 72.41%
💔 `d_a_obj_tuboNP/REL/d/a/obj/d_a_obj_tubo | dAcOtubo_c::fn_272_2670()` -16 bytes -> 98.28%
💔 `d_a_obj_ivy_ropeNP/REL/d/a/obj/d_a_obj_ivy_rope | dAcOivyRope_c::fn_256_ABA0()` -12 bytes -> 88.00%
💔 `d_a_obj_ivy_ropeNP/REL/d/a/obj/d_a_obj_ivy_rope | dAcOivyRope_c::fn_256_DE80()` -8 bytes -> 91.30%
💔 `d_a_obj_ivy_ropeNP/REL/d/a/obj/d_a_obj_ivy_rope | dAcOivyRope_c::fn_256_DEE0()` -8 bytes -> 90.00%
📉 `d_a_e_sf4NP/REL/d/a/e/d_a_e_sf4 | dAcEsf4_c::~dAcEsf4_c()` -48 bytes -> 22.92%
📉 `d_a_e_bc_arrowNP/REL/d/a/e/d_a_e_bc_arrow | dAcEbcarrow_c::~dAcEbcarrow_c()` -36 bytes -> 43.90%
📉 `d_a_b_asuraNP/REL/d/a/b/d_a_b_asura | dAcBAsura_c::~dAcBAsura_c()` -35 bytes -> 9.87%
📉 `d_a_e_bsNP/REL/d/a/e/d_a_e_bs | dAcEbs_c::~dAcEbs_c()` -32 bytes -> 33.04%
📉 `d_a_e_gerockNP/REL/d/a/e/d_a_e_gerock | dAcEgerock_c::~dAcEgerock_c()` -28 bytes -> 35.19%
📉 `d_a_e_tn2NP/REL/d/a/e/d_a_e_tn2 | dAcEtn2_c::~dAcEtn2_c()` -28 bytes -> 8.86%
📉 `d_a_obj_ivy_ropeNP/REL/d/a/obj/d_a_obj_ivy_rope | dAcOivyRope_c::createBase()` -28 bytes -> 4.73%
...and 35 more regressions