### PR TITLE
Fix GitHub token link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information, see the [wiki](https://wiki.decomp.dev/tools/decomp-dev).
    ```bash
    cp config.example.yml config.yml
    ```
-4. [Create a new GitHub personal access token](https://github.com/settings/tokens/new?description=decomp.dev&scopes=workflow,write:discussion) with scopes `workflow`, `write:discussion`. Set it in `config.yml`:
+4. [Create a new GitHub personal access token](https://github.com/settings/tokens/new?description=decomp.dev&scopes=repo,workflow,write:discussion) with scopes `workflow`, `write:discussion`. Set it in `config.yml`:
     ```yaml
     github:
       token: ghp_abcd1234abcd1234abcd1234abcd1234abcd


### PR DESCRIPTION
The "repo" permissions is required to download workflows too. Normally, it's supposed to be impossible to have the "workflow" permission without the "repo" permission, but there's a GitHub bug where it won't automatically check the latter (or even let you manually check it) if the former was selected by clicking a link like this one in the readme instead of the user manually clicking the checkbox. This puts the token into an invalid state that results in a series of confusing errors:

* decomp.dev will tell the user "No workflow runs containing reports found." even though there are
* Which is because the zip extracting fails to unpack the zip files with the error "Could not find EOCD"
* Which is because it's not actually a zip file, it's a json error message from GitHub saying "You must have the actions scope to download artifacts.", even though that permission is already checked
* Which is because it's supposed to be impossible to be missing "repo" perms when you already have "workflow" perms, so GitHub doesn't bother telling you that "repo" is the one you're actually missing

(Also, this GitHub bug doesn't affect "read:discussion", that one autochecks even though it's not in the URL, it's just "repo" that's broken)