### PR TITLE
Implement treemap filtering

### DIFF
--- a/crates/images/src/treemap.rs
+++ b/crates/images/src/treemap.rs
@@ -37,7 +37,7 @@ pub fn unit_color(fuzzy_match_percent: f32) -> String {
         hsl(120, 100, 39)
     } else {
         let nonmatch = hsl(221, 0, 21);
-        let nearmatch = hsl(221, 50, 35);
+        let nearmatch = hsl(221, 100, 35);
         nonmatch.mix(nearmatch, fuzzy_match_percent / 100.0)
     })
 }

--- a/crates/images/src/treemap.rs
+++ b/crates/images/src/treemap.rs
@@ -23,20 +23,26 @@ where
     });
 }
 
-fn hsl(h: u16, s: u8, l: u8) -> Srgb {
+pub fn hsl(h: u16, s: u8, l: u8) -> Srgb {
     let hsl = Hsl::new(h as f32, s as f32 / 100.0, l as f32 / 100.0);
     Srgb::from_color(hsl)
 }
 
+pub fn color_mix(c1: Srgb, c2: Srgb, percent: f32) -> Srgb {
+    c1.mix(c2, percent)
+}
+
 pub fn unit_color(fuzzy_match_percent: f32) -> String {
-    let color;
-    if fuzzy_match_percent == 100.0 {
-        color = hsl(120, 100, 39);
+    html_color(if fuzzy_match_percent == 100.0 {
+        hsl(120, 100, 39)
     } else {
         let nonmatch = hsl(221, 0, 21);
         let nearmatch = hsl(221, 50, 35);
-        color = nonmatch.mix(nearmatch, fuzzy_match_percent / 100.0);
-    }
-    let (r, g, b) = color.into_components();
+        nonmatch.mix(nearmatch, fuzzy_match_percent / 100.0)
+    })
+}
+
+pub fn html_color(c: Srgb) -> String {
+    let (r, g, b) = c.into_components();
     format!("#{:02x}{:02x}{:02x}", (r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
 }

--- a/crates/images/src/treemap.rs
+++ b/crates/images/src/treemap.rs
@@ -1,4 +1,4 @@
-use palette::{Mix, Srgb};
+use palette::{FromColor, Hsl, Mix, Srgb};
 use streemap::Rect;
 
 pub fn layout_units<T, S, R>(items: &mut [T], aspect: f32, size_fn: S, mut set_rect_fn: R)
@@ -23,13 +23,20 @@ where
     });
 }
 
-fn rgb(r: u8, g: u8, b: u8) -> Srgb {
-    Srgb::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
+fn hsl(h: u16, s: u8, l: u8) -> Srgb {
+    let hsl = Hsl::new(h as f32, s as f32 / 100.0, l as f32 / 100.0);
+    Srgb::from_color(hsl)
 }
 
 pub fn unit_color(fuzzy_match_percent: f32) -> String {
-    let red = rgb(42, 49, 64);
-    let green = rgb(0, 200, 0);
-    let (r, g, b) = red.mix(green, fuzzy_match_percent / 100.0).into_components();
+    let color;
+    if fuzzy_match_percent == 100.0 {
+        color = hsl(120, 100, 39);
+    } else {
+        let nonmatch = hsl(221, 0, 21);
+        let nearmatch = hsl(221, 50, 35);
+        color = nonmatch.mix(nearmatch, fuzzy_match_percent / 100.0);
+    }
+    let (r, g, b) = color.into_components();
     format!("#{:02x}{:02x}{:02x}", (r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
 }

--- a/crates/images/src/treemap.rs
+++ b/crates/images/src/treemap.rs
@@ -11,7 +11,7 @@ where
     } else {
         Rect::from_size(aspect, 1.0)
     };
-    streemap::ordered_pivot_by_middle(rect, items, size_fn, |item, mut rect| {
+    streemap::binary(rect, items, size_fn, |item, mut rect| {
         if aspect > 1.0 {
             rect.y *= aspect;
             rect.h *= aspect;

--- a/crates/web/src/handlers/report.rs
+++ b/crates/web/src/handlers/report.rs
@@ -959,6 +959,9 @@ async fn render_report(
                             }
                         }
                     }
+                    label {
+                        input name="filter" required placeholder="Filter, e.g.: 'camera <70% >10kb'";
+                    }
                     @if units.is_empty() {
                         p.muted {
                             @if current_unit.is_some() {

--- a/crates/web/src/handlers/treemap.rs
+++ b/crates/web/src/handlers/treemap.rs
@@ -27,8 +27,8 @@ pub fn render_svg(units: &[ReportTemplateUnit], w: u32, h: u32) -> String {
                         stop offset="0%" stop-color=(complete_c0) {}
                         stop offset="100%" stop-color=(complete_c1) {}
                     } @else {
-                        stop offset="0%" stop-color=(html_color(color_mix(hsl(221, 0, 21), hsl(221, 50, 35), pct / 100.0))) {}
-                        stop offset="100%" stop-color=(html_color(color_mix(hsl(221, 0, 5), hsl(221, 50, 15), pct / 100.0))) {}
+                        stop offset="0%" stop-color=(html_color(color_mix(hsl(221, 0, 21), hsl(221, 100, 35), pct / 100.0))) {}
+                        stop offset="100%" stop-color=(html_color(color_mix(hsl(221, 0, 5), hsl(221, 100, 15), pct / 100.0))) {}
                     }
                 }
             }

--- a/crates/web/src/handlers/treemap.rs
+++ b/crates/web/src/handlers/treemap.rs
@@ -1,22 +1,45 @@
 use anyhow::Result;
-use decomp_dev_images::svg;
+use decomp_dev_images::{
+    svg,
+    treemap::{color_mix, hsl, html_color},
+};
 use image::ImageFormat;
 use maud::{PreEscaped, html};
 
 use crate::handlers::report::ReportTemplateUnit;
 
 pub fn render_svg(units: &[ReportTemplateUnit], w: u32, h: u32) -> String {
+    let complete_c0 = html_color(hsl(120, 100, 39));
+    let complete_c1 = html_color(hsl(120, 100, 17));
     html! {
         (PreEscaped("<?xml version=\"1.0\" encoding=\"utf-8\"?>"))
-        svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox=(format!("0 0 {w} {h}")) {
-            style { ".unit { stroke: #000; stroke-width: 1; }" }
-            @for unit in units {
+        svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox=(format!("0 0 {w} {h}")) width=(w) height=(h) {
+            style { ".unit { stroke: #000; stroke-width: 0.5; }" }
+            @for (i, unit) in units.iter().enumerate() {
+                radialGradient id=(format!("unit-{i}")) 
+                    gradientUnits="userSpaceOnUse"
+                    cx=(format!("{}%", (unit.x + (unit.w * 0.4)) * 100.0))
+                    cy=(format!("{}%", (unit.y + (unit.h * 0.4)) * 100.0)) 
+                    fr=(format!("{}%", (unit.w + unit.h) * 10.0)) 
+                    r=(format!("{}%", (unit.w + unit.h) * 50.0)) {
+                    @let pct = unit.fuzzy_match_percent;
+                    @if pct == 100.0 {
+                        stop offset="0%" stop-color=(complete_c0) {}
+                        stop offset="100%" stop-color=(complete_c1) {}
+                    } @else {
+                        stop offset="0%" stop-color=(html_color(color_mix(hsl(221, 0, 21), hsl(221, 50, 35), pct / 100.0))) {}
+                        stop offset="100%" stop-color=(html_color(color_mix(hsl(221, 0, 5), hsl(221, 50, 15), pct / 100.0))) {}
+                    }
+                }
+            }
+            @for (i, unit) in units.iter().enumerate() {
+                @let pct = unit.fuzzy_match_percent.floor();
                 rect.unit
                     width=(format!("{}%", unit.w * 100.0))
                     height=(format!("{}%", unit.h * 100.0))
                     x=(format!("{}%", unit.x * 100.0))
                     y=(format!("{}%", unit.y * 100.0))
-                    fill=(unit.color) {}
+                    fill=(format!("url(#unit-{i})")) {}
             }
         }
     }

--- a/crates/web/src/handlers/treemap.rs
+++ b/crates/web/src/handlers/treemap.rs
@@ -27,13 +27,12 @@ pub fn render_svg(units: &[ReportTemplateUnit], w: u32, h: u32) -> String {
                         stop offset="0%" stop-color=(complete_c0) {}
                         stop offset="100%" stop-color=(complete_c1) {}
                     } @else {
-                        stop offset="0%" stop-color=(html_color(color_mix(hsl(221, 0, 21), hsl(221, 100, 35), pct / 100.0))) {}
-                        stop offset="100%" stop-color=(html_color(color_mix(hsl(221, 0, 5), hsl(221, 100, 15), pct / 100.0))) {}
+                        stop offset="0%" stop-color=(html_color(color_mix(hsl(200, 0, 21), hsl(200, 100, 35), pct / 100.0))) {}
+                        stop offset="100%" stop-color=(html_color(color_mix(hsl(200, 0, 15), hsl(200, 100, 15), pct / 100.0))) {}
                     }
                 }
             }
             @for (i, unit) in units.iter().enumerate() {
-                @let pct = unit.fuzzy_match_percent.floor();
                 rect.unit
                     width=(format!("{}%", unit.w * 100.0))
                     height=(format!("{}%", unit.h * 100.0))

--- a/js/env.d.ts
+++ b/js/env.d.ts
@@ -10,7 +10,7 @@ type Unit = {
   w: number;
   h: number;
   // Runtime fields
-  visible: boolean;
+  filtered: boolean;
 };
 
 type Measures = {

--- a/js/env.d.ts
+++ b/js/env.d.ts
@@ -9,6 +9,8 @@ type Unit = {
   y: number;
   w: number;
   h: number;
+  // Runtime fields
+  visible: boolean;
 };
 
 type Measures = {

--- a/js/history.ts
+++ b/js/history.ts
@@ -12,6 +12,9 @@ function percentValue(
   _seriesIdx: number,
   _idx: number | null,
 ) {
+  if (rawValue > 99.99 && rawValue < 100.0) {
+    rawValue = 99.99;
+  }
   return rawValue == null ? '' : `${rawValue.toFixed(2)}%`;
 }
 

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -159,12 +159,12 @@ const drawUnits = (
   for (const unit of units) {
     const { x, y, w, h } = unitBounds(unit, width, height);
 
-    let centerColor, outerColor;
+    let innerColor, outerColor;
     if (unit.fuzzy_match_percent == 100.0) {
-      centerColor = "hsl(120 100% 39%)";
+      innerColor = "hsl(120 100% 39%)";
       outerColor = "hsl(120 100% 17%)";
     } else {
-      centerColor = `color-mix(in srgb, hsl(221 0% 21%), hsl(221 50% 35%) ${unit.fuzzy_match_percent}%)`;
+      innerColor = `color-mix(in srgb, hsl(221 0% 21%), hsl(221 50% 35%) ${unit.fuzzy_match_percent}%)`;
       outerColor = `color-mix(in srgb, hsl(221 0% 5%), hsl(221 50% 15%) ${unit.fuzzy_match_percent}%)`;
     }
     const cx = x + (w * 0.4);
@@ -172,7 +172,7 @@ const drawUnits = (
     const r0 = (w + h) * 0.1;
     const r1 = (w + h) * 0.5;
     const gradient = ctx.createRadialGradient(cx, cy, r0, cx, cy, r1);
-    gradient.addColorStop(0, centerColor);
+    gradient.addColorStop(0, innerColor);
     gradient.addColorStop(1, outerColor);
     ctx.fillStyle = gradient;
 

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -158,7 +158,12 @@ const drawUnits = (
     ctx.beginPath();
     ctx.rect(x, y, w, h);
 
+    ctx.save();
+    if (unit.filtered) {
+      ctx.clip();
+    }
     ctx.stroke();
+    ctx.restore();
 
     if (unit.filtered) {
       ctx.globalAlpha = 0.1;

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -158,7 +158,24 @@ const drawUnits = (
 ) => {
   for (const unit of units) {
     const { x, y, w, h } = unitBounds(unit, width, height);
-    ctx.fillStyle = unit.color;
+
+    let centerColor, outerColor;
+    if (unit.fuzzy_match_percent == 100.0) {
+      centerColor = "hsl(120 100% 39%)";
+      outerColor = "hsl(120 100% 17%)";
+    } else {
+      centerColor = `color-mix(in srgb, hsl(221 0% 21%), hsl(221 50% 35%) ${unit.fuzzy_match_percent}%)`;
+      outerColor = `color-mix(in srgb, hsl(221 0% 5%), hsl(221 50% 15%) ${unit.fuzzy_match_percent}%)`;
+    }
+    const cx = x + (w * 0.4);
+    const cy = y + (h * 0.4);
+    const r0 = (w + h) * 0.1;
+    const r1 = (w + h) * 0.5;
+    const gradient = ctx.createRadialGradient(cx, cy, r0, cx, cy, r1);
+    gradient.addColorStop(0, centerColor);
+    gradient.addColorStop(1, outerColor);
+    ctx.fillStyle = gradient;
+
     ctx.beginPath();
     ctx.rect(x, y, w, h);
 

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -263,7 +263,7 @@ const findUnit = (
   const { width, height, left, top } = canvas.getBoundingClientRect();
   const mx = clientX - left;
   const my = clientY - top;
-  let nearOverlapUnit = null;
+  let nearOverlapUnit: Unit | null = null;
   const epsilon = 3;
   for (const unit of units) {
     if (unit.filtered) {

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -154,15 +154,17 @@ const drawUnits = (
 ) => {
   for (const unit of units) {
     const { x, y, w, h } = unitBounds(unit, width, height);
-    if (unit.filtered) {
-      ctx.globalAlpha = 0.1;
-    }
     ctx.fillStyle = unit.color;
     ctx.beginPath();
     ctx.rect(x, y, w, h);
+
+    ctx.stroke();
+
+    if (unit.filtered) {
+      ctx.globalAlpha = 0.1;
+    }
     ctx.fill();
     ctx.globalAlpha = 1.0;
-    ctx.stroke();
   }
 };
 

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -353,7 +353,7 @@ const updatePixelRatio = (redraw: () => void, now: boolean) => {
   }
 };
 
-const checkFilterTermMatches = (term: string, unit: Unit) => {
+const checkFilterTermMatches = (term: string, unit: Unit): boolean => {
   let special_term_regexp = new RegExp(`^(>|<|>=|<=|=|==|!=)(\\d+(?:\\.\\d+)?)(%|${UNITS.join("|")})$`, "i");
   const match = term.match(special_term_regexp);
   if (match) {
@@ -397,6 +397,8 @@ const checkFilterTermMatches = (term: string, unit: Unit) => {
         return lhs === rhs;
       case "!=":
         return lhs !== rhs;
+      default:
+        return false;
     }
   } else {
     // Filter based on name.

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -64,9 +64,13 @@ const drawTooltip = (
   ctx.textBaseline = 'middle';
 
   const { x, y, w, h } = unitBounds(unit, width, height);
+  let percent = unit.fuzzy_match_percent;
+  if (percent > 99.99 && percent < 100.0) {
+    percent = 99.99;
+  }
   const text = ellipsize(
     ctx,
-    `${unit.name} • ${formatSize(unit.total_code)} • ${unit.fuzzy_match_percent.toFixed(2)}%`,
+    `${unit.name} • ${formatSize(unit.total_code)} • ${percent.toFixed(2)}%`,
     width,
   );
   const m = ctx.measureText(text);

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -166,8 +166,8 @@ const drawUnits = (
       innerColor = 'hsl(120 100% 39%)';
       outerColor = 'hsl(120 100% 17%)';
     } else {
-      innerColor = `color-mix(in srgb, hsl(221 0% 21%), hsl(221 100% 35%) ${unit.fuzzy_match_percent}%)`;
-      outerColor = `color-mix(in srgb, hsl(221 0% 5%), hsl(221 100% 15%) ${unit.fuzzy_match_percent}%)`;
+      innerColor = `color-mix(in srgb, hsl(200 0% 21%), hsl(200 100% 35%) ${unit.fuzzy_match_percent}%)`;
+      outerColor = `color-mix(in srgb, hsl(200 0% 15%), hsl(200 100% 15%) ${unit.fuzzy_match_percent}%)`;
     }
     const cx = x + w * 0.4;
     const cy = y + h * 0.4;

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -166,8 +166,8 @@ const drawUnits = (
       innerColor = 'hsl(120 100% 39%)';
       outerColor = 'hsl(120 100% 17%)';
     } else {
-      innerColor = `color-mix(in srgb, hsl(221 0% 21%), hsl(221 50% 35%) ${unit.fuzzy_match_percent}%)`;
-      outerColor = `color-mix(in srgb, hsl(221 0% 5%), hsl(221 50% 15%) ${unit.fuzzy_match_percent}%)`;
+      innerColor = `color-mix(in srgb, hsl(221 0% 21%), hsl(221 100% 35%) ${unit.fuzzy_match_percent}%)`;
+      outerColor = `color-mix(in srgb, hsl(221 0% 5%), hsl(221 100% 15%) ${unit.fuzzy_match_percent}%)`;
     }
     const cx = x + w * 0.4;
     const cy = y + h * 0.4;

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -350,6 +350,13 @@ const drawTreemap = (id: string, clickable: boolean, units: Unit[]) => {
       return;
     }
     updateFilter(evt.currentTarget.value);
+    const url = new URL(window.location.href);
+    if (evt.currentTarget.value) {
+      url.searchParams.set('filter', evt.currentTarget.value);
+    } else {
+      url.searchParams.delete('filter');
+    }
+    window.history.replaceState({}, '', url);
   };
 
   canvas.addEventListener('mousemove', (e) => {
@@ -369,6 +376,7 @@ const drawTreemap = (id: string, clickable: boolean, units: Unit[]) => {
     }
     const url = new URL(window.location.href);
     url.searchParams.set('unit', unit.name);
+    url.searchParams.delete('filter');
     window.location.href = url.toString();
   });
   const filterInput = document.querySelector('input[name="filter"]');
@@ -456,3 +464,15 @@ const checkFilterTermMatches = (term: string, unit: Unit): boolean => {
 };
 
 window.drawTreemap = drawTreemap;
+
+(function () {
+  const url = new URL(window.location.href);
+  const filterFromUrl = url.searchParams.get('filter');
+  if (filterFromUrl) {
+    const filterInput = document.querySelector('input[name="filter"]');
+    if (filterInput && filterInput instanceof HTMLInputElement) {
+      filterInput.value = filterFromUrl;
+      filterInput.scrollIntoView();
+    }
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "decompal-rs",
+  "name": "decomp.dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Implements a filter field above the treemap that allows the user to filter visible units/functions.

It supports filtering by name, match percent, and total code size:
<img width="1030" height="793" alt="image" src="https://github.com/user-attachments/assets/4e5f231d-c154-409c-8a40-65d2c3af8ff1" />

It doesn't try to recalculate the treemap layout after it's filtered, since that's done serverside. Instead it just makes items that got filtered out be invisible and disable interacting with them.
This mostly works, the only issue is units that are extremely thin, like this unit which is very wide but less than a pixel tall:
<img width="996" height="709" alt="image" src="https://github.com/user-attachments/assets/f671b1b5-81aa-4c36-a5bd-c28de1eda5ce" />
Normally these are impossible to hover over because the mouse will never be inside a subpixel box, so to avoid this issue, I had it count units that are a few pixels away from your cursor as being hovered over when your cursor is hovering over an invisible unit. This makes it possible to select these very thin units, but only when the units surrounding them have been filtered out:
<img width="977" height="713" alt="image" src="https://github.com/user-attachments/assets/b3be8e22-147a-45c4-93f6-58cadd58af0c" />

Edit: Updated preview:
<img width="976" height="590" alt="image" src="https://github.com/user-attachments/assets/c40a51d7-7704-41d7-a90e-54624ad16495" />
