### PR TITLE
Don't round partially-matched percentages to 0.00% or 100.00%

### DIFF
--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -71,3 +71,12 @@ pub fn size(value: u64) -> String {
     }
     format!("{:.2} {}", value, units[unit])
 }
+
+/// Formats a progress percentage as a string, and prevents partial matches from being rounded to 0.00% or 100.00%.
+pub fn format_percent(value: f32) -> String {
+    let mut value = value;
+    if value > 0.0 && value < 100.0 {
+        value = value.clamp(0.01, 99.99);
+    }
+    format!("{value:.2}%")
+}

--- a/crates/images/src/badge.rs
+++ b/crates/images/src/badge.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use decomp_dev_core::util::size;
+use decomp_dev_core::util::{format_percent, size};
 use image::ImageFormat;
 use objdiff_core::bindings::report::Measures;
 use serde::{Deserialize, Serialize};
@@ -29,8 +29,6 @@ pub struct ShieldResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     label_color: Option<String>,
 }
-
-fn format_percent(value: f32) -> String { format!("{value:.2}%") }
 
 fn format_bytes(a: u64, b: u64) -> String {
     let mut a_buf = num_format::Buffer::default();

--- a/crates/images/src/treemap.rs
+++ b/crates/images/src/treemap.rs
@@ -28,9 +28,7 @@ pub fn hsl(h: u16, s: u8, l: u8) -> Srgb {
     Srgb::from_color(hsl)
 }
 
-pub fn color_mix(c1: Srgb, c2: Srgb, percent: f32) -> Srgb {
-    c1.mix(c2, percent)
-}
+pub fn color_mix(c1: Srgb, c2: Srgb, percent: f32) -> Srgb { c1.mix(c2, percent) }
 
 pub fn unit_color(fuzzy_match_percent: f32) -> String {
     html_color(if fuzzy_match_percent == 100.0 {

--- a/crates/web/src/handlers/common.rs
+++ b/crates/web/src/handlers/common.rs
@@ -13,7 +13,10 @@ use axum::{
     response::{IntoResponseParts, ResponseParts},
 };
 use decomp_dev_auth::CurrentUser;
-use decomp_dev_core::{AppError, util::size};
+use decomp_dev_core::{
+    AppError,
+    util::{format_percent, size},
+};
 use maud::{Markup, PreEscaped, Render, html};
 use objdiff_core::bindings::report::Measures;
 use regex::Regex;
@@ -305,8 +308,8 @@ impl TemplateContext {
                 "progress-section",
                 measures.complete_code_percent - current_percent,
                 format!(
-                    "{:.2}% fully linked ({})",
-                    measures.complete_code_percent,
+                    "{} fully linked ({})",
+                    format_percent(measures.complete_code_percent),
                     size(measures.complete_code)
                 ),
             );
@@ -317,8 +320,8 @@ impl TemplateContext {
                 if current_percent > 0.0 { "progress-section striped" } else { "progress-section" },
                 measures.matched_code_percent - current_percent,
                 format!(
-                    "{:.2}% perfect match ({})",
-                    measures.matched_code_percent,
+                    "{} perfect match ({})",
+                    format_percent(measures.matched_code_percent),
                     size(measures.matched_code)
                 ),
             );
@@ -328,7 +331,7 @@ impl TemplateContext {
             out.push(
                 "progress-section striped fuzzy",
                 measures.fuzzy_match_percent - current_percent,
-                format!("{:.2}% fuzzy match", measures.fuzzy_match_percent),
+                format!("{} fuzzy match", format_percent(measures.fuzzy_match_percent)),
             );
         }
         out
@@ -345,8 +348,8 @@ impl TemplateContext {
                 "progress-section",
                 measures.complete_data_percent - current_percent,
                 format!(
-                    "{:.2}% fully linked ({})",
-                    measures.complete_data_percent,
+                    "{} fully linked ({})",
+                    format_percent(measures.complete_data_percent),
                     size(measures.complete_data)
                 ),
             );
@@ -357,8 +360,8 @@ impl TemplateContext {
                 if current_percent > 0.0 { "progress-section striped" } else { "progress-section" },
                 measures.matched_data_percent - current_percent,
                 format!(
-                    "{:.2}% perfect match ({})",
-                    measures.matched_data_percent,
+                    "{} perfect match ({})",
+                    format_percent(measures.matched_data_percent),
                     size(measures.matched_data)
                 ),
             );

--- a/crates/web/src/handlers/project.rs
+++ b/crates/web/src/handlers/project.rs
@@ -14,7 +14,7 @@ use decomp_dev_core::{
         CachedReportFile, Commit, Platform, ProjectInfo, ProjectVisibility, ReportInner,
         project_visibility,
     },
-    util::{UrlExt, size},
+    util::{UrlExt, format_percent, size},
 };
 use maud::{DOCTYPE, Markup, html};
 use objdiff_core::bindings::report::Measures;
@@ -413,11 +413,11 @@ fn project_fragment(
                     (size(ctx.measures.total_code))
                     " total code"
                 } @else {
-                    (format!("{:.2}%", ctx.measures.matched_code_percent))
+                    (format_percent(ctx.measures.matched_code_percent))
                     " decompiled"
                     @if ctx.measures.complete_code_percent > 0.0 {
                         " | "
-                        (format!("{:.2}%", ctx.measures.complete_code_percent))
+                        (format_percent(ctx.measures.complete_code_percent))
                         " fully linked"
                     }
                 }

--- a/crates/web/src/handlers/report.rs
+++ b/crates/web/src/handlers/report.rs
@@ -11,7 +11,7 @@ use decomp_dev_auth::CurrentUser;
 use decomp_dev_core::{
     AppError, FullUri,
     models::{FullReportFile, ProjectInfo, ProjectVisibility, project_visibility},
-    util::{UrlExt, size},
+    util::{UrlExt, format_percent, size},
 };
 use decomp_dev_images::{
     badge,
@@ -781,7 +781,7 @@ async fn render_report(
                     link rel="next" href=(next_commit_path);
                 }
                 meta name="description" content=(format!("Decompilation progress report for {project_name}"));
-                meta property="og:title" content=(format!("{project_short_name_with_label} is {:.2}% decompiled", measures.matched_code_percent));
+                meta property="og:title" content=(format!("{project_short_name_with_label} is {} decompiled", format_percent(measures.matched_code_percent)));
                 meta property="og:description" content=(format!("Decompilation progress report for {project_name}"));
                 meta property="og:image" content=(image_url);
                 meta property="og:url" content=(canonical_url);
@@ -861,9 +861,9 @@ async fn render_report(
                         span.icon-github { " " }
                         span.md { "Repository" }
                     }
-                    h3.report-title { (format!("{project_short_name_with_label} is {:.2}% decompiled", measures.matched_code_percent)) }
+                    h3.report-title { (format!("{project_short_name_with_label} is {} decompiled", format_percent(measures.matched_code_percent))) }
                     @if current_unit.is_none() && measures.complete_code_percent > 0.0 {
-                        h4.muted { (format!("{:.2}% fully linked", measures.complete_code_percent)) }
+                        h4.muted { (format!("{} fully linked", format_percent(measures.complete_code_percent))) }
                     }
                     @if let Some(source_file_url) = source_file_url {
                         h4.muted {
@@ -1079,7 +1079,7 @@ async fn render_history(
                 (ctx.chunks("history", Load::Preload).await)
                 link rel="canonical" href=(canonical_url);
                 meta name="description" content=(format!("Decompilation progress history for {project_name}"));
-                meta property="og:title" content=(format!("{project_short_name_with_label} is {:.2}% decompiled", measures.matched_code_percent));
+                meta property="og:title" content=(format!("{project_short_name_with_label} is {} decompiled", format_percent(measures.matched_code_percent)));
                 meta property="og:description" content=(format!("Decompilation progress history for {project_name}"));
                 meta property="og:image" content=(image_url);
                 meta property="og:url" content=(canonical_url);

--- a/js/history.ts
+++ b/js/history.ts
@@ -1,4 +1,5 @@
 import uPlot from 'uplot';
+import { formatPercent } from './util';
 
 const height = 400;
 const stroke = '#a9a9b3';
@@ -12,10 +13,7 @@ function percentValue(
   _seriesIdx: number,
   _idx: number | null,
 ) {
-  if (rawValue > 99.99 && rawValue < 100.0) {
-    rawValue = 99.99;
-  }
-  return rawValue == null ? '' : `${rawValue.toFixed(2)}%`;
+  return rawValue == null ? '' : formatPercent(rawValue);
 }
 
 function renderChart(id: string, data: ReportHistoryEntry[]) {

--- a/js/treemap.ts
+++ b/js/treemap.ts
@@ -1,3 +1,5 @@
+import { formatPercent } from './util';
+
 const unitBounds = (unit: Unit, width: number, height: number) => {
   return {
     x: unit.x * width,
@@ -70,7 +72,7 @@ const drawTooltip = (
   }
   const text = ellipsize(
     ctx,
-    `${unit.name} • ${formatSize(unit.total_code)} • ${percent.toFixed(2)}%`,
+    `${unit.name} • ${formatSize(unit.total_code)} • ${formatPercent(unit.fuzzy_match_percent)}`,
     width,
   );
   const m = ctx.measureText(text);

--- a/js/util.ts
+++ b/js/util.ts
@@ -1,0 +1,11 @@
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+// Formats a progress percentage as a string, and prevents partial matches from being rounded to 0.00% or 100.00%.
+export function formatPercent(value: number) {
+  if (value !== 0.0 && value !== 100.0) {
+    value = clamp(value, 0.01, 99.99);
+  }
+  return `${value.toFixed(2)}%`;
+}


### PR DESCRIPTION
I already started doing this in the other PRs but I just noticed I missed the progress bar, so now I went through and made sure all percents in the codebase use the same display logic now.