### PR TITLE
Replace broken match emoji from 💔 to 🥀

### DIFF
--- a/crates/github/src/changes.rs
+++ b/crates/github/src/changes.rs
@@ -194,7 +194,7 @@ impl ChangeKind {
     fn emoji(self) -> &'static str {
         match self {
             ChangeKind::NewMatch => "✅",
-            ChangeKind::BrokenMatch => "💔",
+            ChangeKind::BrokenMatch => "🥀",
             ChangeKind::Improvement => "📈",
             ChangeKind::Regression => "📉",
         }


### PR DESCRIPTION
Change the BrokenMatch emoji from broken heart (💔) to wilted flower
(🥀) for better visual distinction in GitHub PR comments.

https://claude.ai/code/session_018LfHdFcrSQFoHBWZSAxL6v