### PR TITLE
Fix github urls with version numbers being read as file extensions

### DIFF
--- a/crates/web/src/handlers/report.rs
+++ b/crates/web/src/handlers/report.rs
@@ -14,7 +14,7 @@ use decomp_dev_core::{
     util::{UrlExt, format_percent, size},
 };
 use decomp_dev_images::{
-    badge,
+    badge, image_mime_from_ext,
     treemap::{layout_units, unit_color},
 };
 use image::ImageFormat;
@@ -231,8 +231,8 @@ impl From<&Measures> for TemplateMeasures {
 }
 
 fn is_valid_extension(ext: &str) -> bool {
-    // FIXME: hack for versions that have .nn where nn is a number
-    ext.chars().any(|c| c.is_ascii_alphabetic())
+    matches!(ext.to_ascii_lowercase().as_str(), "json" | "binpb" | "proto" | "svg")
+        || image_mime_from_ext(ext).is_some()
 }
 
 fn extract_extension(params: ReportParams) -> (ReportParams, Option<String>) {


### PR DESCRIPTION
is_valid_extension accepted any suffix containing an ASCII letter, so a repo name like chameleonTwistv1.0-JP was split into chameleonTwistv1 + ext 0-JP. parse_accept doesn't recognise that extension and returns an empty vec, so get_report bails with 406 before the project is ever looked up.

Match against the extensions parse_accept actually serves instead. This also covers the numeric-suffix case the previous FIXME worked around.

Fixes #43