### PR TITLE
feat: add default category selector to project settings

### DIFF
--- a/crates/web/src/handlers/manage.rs
+++ b/crates/web/src/handlers/manage.rs
@@ -24,6 +24,7 @@ use decomp_dev_github::{
 use decomp_dev_jobs::RefreshProjectJob;
 use itertools::Itertools;
 use maud::{DOCTYPE, Markup, html};
+use objdiff_core::bindings::report::ReportCategory;
 use serde::{Deserialize, Serialize};
 use tower_sessions::Session;
 
@@ -399,6 +400,17 @@ async fn render_manage_project(
         format!("/manage/{}/{}/refresh", project_info.project.owner, project_info.project.repo);
     let default_version = project_info.default_version();
 
+    let mut version_categories = Vec::new();
+    if let Some(commit) = &project_info.commit {
+        for version in &project_info.report_versions {
+            let report = state.db.get_report(project_info.project.id, &commit.sha, version).await?;
+            version_categories
+                .push((version, report.map(|r| r.report.categories.clone()).unwrap_or_default()));
+        }
+    }
+    let categories = latest_report.map(|r| r.report.categories.as_slice()).unwrap_or_default();
+    let current_category = project_info.project.default_category.as_deref();
+
     let current_name = project_info.project.name.as_deref().unwrap_or("");
     let current_short_name = project_info.project.short_name.as_deref().unwrap_or("");
     let current_platform = project_info.project.platform.as_deref();
@@ -507,6 +519,18 @@ async fn render_manage_project(
                                 }
                             }
                             label {
+                                "Default category"
+                                select name="default_category" {
+                                    (category_options(categories, current_category))
+                                }
+                                small { "Used when viewing the project without a category filter. Falls back to All if unavailable in the selected version." }
+                            }
+                            @for (version, categories) in &version_categories {
+                                template data-category-version=(version) {
+                                    (category_options(categories, None))
+                                }
+                            }
+                            label {
                                 "GitHub workflow ID"
                                 input name="workflow_id" type="text" value=(current_workflow_id);
                                 small { "The GitHub Actions workflow that contains report artifacts." }
@@ -589,12 +613,41 @@ async fn render_manage_project(
     Ok((ctx, rendered).into_response())
 }
 
+fn category_options(categories: &[ReportCategory], current: Option<&str>) -> Markup {
+    let current = current.filter(|id| categories.iter().any(|c| c.id == *id));
+    html! {
+        option value="" selected[current.is_none()] { "All" }
+        @for category in categories {
+            option value=(&category.id) selected[current == Some(category.id.as_str())] {
+                (&category.name)
+            }
+        }
+    }
+}
+
+fn validate_category(
+    submitted: Option<&str>,
+    previous: Option<&str>,
+    categories: &[ReportCategory],
+) -> Result<Option<String>, AppError> {
+    // Older forms may omit the field; an explicit empty value selects All.
+    match submitted.or(previous).filter(|id| !id.is_empty()) {
+        None => Ok(None),
+        Some(id) if categories.iter().any(|c| c.id == id) => Ok(Some(id.to_owned())),
+        // A report may have changed since the settings page was loaded, or the
+        // owner may have switched to a version without the saved category.
+        Some(id) if Some(id) == previous => Ok(None),
+        Some(_) => Err(AppError::Status(StatusCode::BAD_REQUEST)),
+    }
+}
+
 #[derive(Debug, TryFromMultipart)]
 pub struct ProjectForm {
     pub name: String,
     pub short_name: String,
     pub platform: String,
     pub default_version: Option<String>,
+    pub default_category: Option<String>,
     pub workflow_id: String,
     pub enable_pr_comments: Option<String>,
     pub pr_report_style: Option<String>,
@@ -626,6 +679,25 @@ pub async fn manage_project_save(
     if !ALL_PLATFORMS.iter().any(|p| p.to_str() == form.platform) {
         return Err(AppError::Status(StatusCode::BAD_REQUEST));
     };
+
+    let default_version = form.default_version.as_deref().filter(|v| !v.is_empty());
+    if default_version.is_some_and(|v| !project_info.report_versions.iter().any(|r| r == v)) {
+        return Err(AppError::Status(StatusCode::BAD_REQUEST));
+    }
+    let report = if let (Some(version), Some(commit)) = (
+        default_version.or_else(|| project_info.report_versions.first().map(String::as_str)),
+        &project_info.commit,
+    ) {
+        state.db.get_report(project_info.project.id, &commit.sha, version).await?
+    } else {
+        None
+    };
+    let categories = report.as_ref().map(|r| r.report.categories.as_slice()).unwrap_or_default();
+    let default_category = validate_category(
+        form.default_category.as_deref(),
+        project_info.project.default_category.as_deref(),
+        categories,
+    )?;
 
     let mut header_image_id = project_info.project.header_image_id;
     if let Some(header_image) = form.header_image.filter(|b| !b.is_empty()) {
@@ -660,8 +732,8 @@ pub async fn manage_project_save(
         repo: project_info.project.repo,
         name: (!name.is_empty()).then_some(name.to_string()),
         short_name: (!short_name.is_empty()).then_some(short_name.to_string()),
-        default_category: project_info.project.default_category,
-        default_version: form.default_version,
+        default_category,
+        default_version: default_version.map(str::to_owned),
         platform: (!platform.is_empty()).then_some(platform.to_string()),
         workflow_id: (!workflow_id.is_empty()).then_some(workflow_id.to_string()),
         // If there's no installation ID, use the existing value
@@ -743,3 +815,6 @@ pub async fn delete_commit(
     let redirect_url = format!("/manage/{}/{}", params.owner, params.repo);
     Ok(Redirect::to(&redirect_url).into_response())
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/web/src/handlers/manage/tests.rs
+++ b/crates/web/src/handlers/manage/tests.rs
@@ -1,0 +1,251 @@
+use std::sync::Arc;
+
+use decomp_dev_core::{config::Config, models::Commit};
+use decomp_dev_db::Database;
+use decomp_dev_github::{
+    GitHub,
+    graphql::{CurrentUserRepository, CurrentUserResponse},
+};
+use decomp_dev_jobs::JobStorage;
+use objdiff_core::bindings::report::{Measures, REPORT_VERSION, Report};
+use time::UtcDateTime;
+
+use super::*;
+
+fn category(id: &str) -> ReportCategory {
+    ReportCategory {
+        id: id.into(),
+        name: format!("Category {id}"),
+        measures: Some(Measures {
+            total_code: 10000,
+            matched_code: 7049,
+            matched_code_percent: 70.49,
+            ..Default::default()
+        }),
+    }
+}
+
+#[test]
+fn category_selection() {
+    let categories = vec![category("game"), category("game/engine")];
+    assert_eq!(
+        validate_category(Some("game/engine"), None, &categories)
+            .map_err(|e| e.into_response().status())
+            .unwrap()
+            .as_deref(),
+        Some("game/engine")
+    );
+    assert_eq!(
+        validate_category(Some(""), Some("game"), &categories)
+            .map_err(|e| e.into_response().status())
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        validate_category(None, None, &[]).map_err(|e| e.into_response().status()).unwrap(),
+        None
+    );
+    assert_eq!(
+        validate_category(None, Some("game"), &categories)
+            .map_err(|e| e.into_response().status())
+            .unwrap()
+            .as_deref(),
+        Some("game")
+    );
+    assert!(matches!(
+        validate_category(Some("unknown"), None, &categories),
+        Err(AppError::Status(StatusCode::BAD_REQUEST))
+    ));
+    assert_eq!(
+        validate_category(Some("game"), Some("game"), &[])
+            .map_err(|e| e.into_response().status())
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        category_options(&[], Some("gone")).into_string(),
+        "<option value=\"\" selected>All</option>"
+    );
+    let markup = category_options(&categories, Some("game/engine")).into_string();
+    assert!(markup.contains("value=\"game/engine\" selected"));
+}
+
+async fn fixture() -> (AppState, CurrentUser) {
+    let config: Config = serde_yaml::from_str("server:\n  port: 3000\ndb:\n  url: 'sqlite::memory:'\n  jobs_url: 'sqlite::memory:'\ngithub:\n  token: test\n").unwrap();
+    let db = Database::new(&config.db).await.unwrap();
+    let project = Project {
+        id: 1,
+        owner: "owner".into(),
+        repo: "game".into(),
+        platform: Some("win32".into()),
+        ..Default::default()
+    };
+    let commit = Commit { sha: "a".repeat(40), timestamp: UtcDateTime::now(), message: None };
+    for (version, categories) in [
+        ("v1", vec![category("game"), category("game/engine")]),
+        ("v2", vec![category("other"), category("game/engine")]),
+    ] {
+        db.insert_report(
+            &project,
+            &commit,
+            version,
+            Box::new(Report {
+                version: REPORT_VERSION,
+                measures: Some(Measures {
+                    total_code: 10000,
+                    matched_code: 4931,
+                    matched_code_percent: 49.31,
+                    ..Default::default()
+                }),
+                categories,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    }
+    let jobs = JobStorage::setup(&config.db).await.unwrap();
+    let state = AppState {
+        config: Arc::new(config),
+        db,
+        jobs,
+        github: Arc::new(GitHub {
+            client: octocrab::Octocrab::builder().build().unwrap(),
+            installations: None,
+        }),
+    };
+    let user = CurrentUser {
+        oauth: None,
+        super_admin: false,
+        data: CurrentUserResponse {
+            id: 1,
+            login: "owner".into(),
+            url: "https://github.com/owner".into(),
+            repositories: vec![CurrentUserRepository {
+                id: 1,
+                owner: "owner".into(),
+                name: "game".into(),
+                permission: RepositoryPermission::Admin,
+            }],
+        },
+    };
+    (state, user)
+}
+
+async fn save(
+    state: &AppState,
+    user: &CurrentUser,
+    version: &str,
+    category: &str,
+) -> Result<Response, AppError> {
+    manage_project_save(
+        Path(ProjectParams { owner: "owner".into(), repo: "game".into() }),
+        State(state.clone()),
+        user.clone(),
+        TypedMultipart(ProjectForm {
+            name: "Game".into(),
+            short_name: "".into(),
+            platform: "win32".into(),
+            default_version: Some(version.into()),
+            default_category: Some(category.into()),
+            workflow_id: "build.yml".into(),
+            enable_pr_comments: None,
+            pr_report_style: None,
+            header_image: None,
+            clear_header_image: None,
+            enabled: Some("on".into()),
+            permanently_disabled: None,
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn saves_validates_and_clears_default_category() {
+    let (state, user) = fixture().await;
+    assert_eq!(
+        save(&state, &user, "v1", "game")
+            .await
+            .map_err(|e| e.into_response().status())
+            .unwrap()
+            .status(),
+        StatusCode::SEE_OTHER
+    );
+    let project = state.db.get_project_by_id(1).await.unwrap().unwrap();
+    assert_eq!(project.default_category.as_deref(), Some("game"));
+    assert_eq!(project.default_version.as_deref(), Some("v1"));
+    for (version, category) in [("v1", "unknown"), ("v1", "other"), ("missing", "game")] {
+        assert!(matches!(
+            save(&state, &user, version, category).await,
+            Err(AppError::Status(StatusCode::BAD_REQUEST))
+        ));
+        assert_eq!(
+            state.db.get_project_by_id(1).await.unwrap().unwrap().default_category.as_deref(),
+            Some("game")
+        );
+    }
+    // Switching versions without JS also clears an unavailable saved category.
+    save(&state, &user, "v2", "game").await.map_err(|e| e.into_response().status()).unwrap();
+    assert_eq!(state.db.get_project_by_id(1).await.unwrap().unwrap().default_category, None);
+    save(&state, &user, "v2", "other").await.map_err(|e| e.into_response().status()).unwrap();
+    save(&state, &user, "v2", "").await.map_err(|e| e.into_response().status()).unwrap();
+    assert_eq!(state.db.get_project_by_id(1).await.unwrap().unwrap().default_category, None);
+
+    // A newer report can remove a category while the settings form is open.
+    save(&state, &user, "v1", "game").await.map_err(|e| e.into_response().status()).unwrap();
+    let project = state.db.get_project_by_id(1).await.unwrap().unwrap();
+    let commit = Commit {
+        sha: "b".repeat(40),
+        timestamp: UtcDateTime::now() + time::Duration::seconds(1),
+        message: None,
+    };
+    state
+        .db
+        .insert_report(
+            &project,
+            &commit,
+            "v1",
+            Box::new(Report {
+                version: REPORT_VERSION,
+                measures: Some(Measures::default()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    save(&state, &user, "v1", "game").await.map_err(|e| e.into_response().status()).unwrap();
+    assert_eq!(state.db.get_project_by_id(1).await.unwrap().unwrap().default_category, None);
+}
+
+#[tokio::test]
+async fn category_save_requires_project_admin() {
+    let (state, mut user) = fixture().await;
+    user.data.repositories[0].permission = RepositoryPermission::Write;
+    assert!(matches!(
+        save(&state, &user, "v1", "game").await,
+        Err(AppError::Status(StatusCode::FORBIDDEN))
+    ));
+    user.data.repositories[0].permission = RepositoryPermission::Admin;
+    let mut project = state.db.get_project_by_id(1).await.unwrap().unwrap();
+    project.permanently_disabled = true;
+    state.db.update_project(&project).await.unwrap();
+    assert!(matches!(
+        save(&state, &user, "v1", "game").await,
+        Err(AppError::Status(StatusCode::FORBIDDEN))
+    ));
+    assert_eq!(state.db.get_project_by_id(1).await.unwrap().unwrap().default_category, None);
+}
+
+#[tokio::test]
+async fn saves_project_without_reports() {
+    let (state, user) = fixture().await;
+    state.db.delete_reports_by_commit(1, &"a".repeat(40)).await.unwrap();
+    save(&state, &user, "", "").await.map_err(|e| e.into_response().status()).unwrap();
+    let project = state.db.get_project_by_id(1).await.unwrap().unwrap();
+    assert_eq!(project.default_version, None);
+    assert_eq!(project.default_category, None);
+    assert!(matches!(
+        save(&state, &user, "", "game").await,
+        Err(AppError::Status(StatusCode::BAD_REQUEST))
+    ));
+}

--- a/js/manage.ts
+++ b/js/manage.ts
@@ -10,3 +10,30 @@ document.querySelectorAll('form[data-loading]').forEach((form) => {
     submitButton.innerText = loadingText || 'Loading...';
   });
 });
+
+const versionSelect = document.querySelector<HTMLSelectElement>(
+  'select[name="default_version"]',
+);
+const categorySelect = document.querySelector<HTMLSelectElement>(
+  'select[name="default_category"]',
+);
+if (versionSelect && categorySelect) {
+  versionSelect.addEventListener('change', () => {
+    const template = Array.from(
+      document.querySelectorAll<HTMLTemplateElement>(
+        'template[data-category-version]',
+      ),
+    ).find(
+      (template) => template.dataset.categoryVersion === versionSelect.value,
+    );
+    const previous = categorySelect.value;
+    categorySelect.replaceChildren(
+      template?.content.cloneNode(true) ?? new Option('All', ''),
+    );
+    categorySelect.value = Array.from(categorySelect.options).some(
+      (option) => option.value === previous,
+    )
+      ? previous
+      : '';
+  });
+}


### PR DESCRIPTION
Project settings expose the default version but do not let owners change `Project.default_category`, which reports already use. Add a **Default category** selector with **All** and the categories from the selected version's latest report.

Changing versions updates the options, preserving the selected category when available and falling back to All otherwise. The save handler validates category and version IDs before writing, clears an unavailable saved category, and persists the choice through the existing field. An omitted category field preserves a valid existing selection for older forms. Existing project-admin checks are unchanged; no database migration is needed.

Validation:
- `cargo test -p decomp-dev-web`: 5 passed, including 4 new tests covering persistence, invalid submissions, hierarchical IDs, version changes, removed categories, projects without reports, and authorization.
- `npm run build`, `biome check js/manage.ts`, and `git diff --check` passed.
- Browser validation with dev-mode login and synthetic two-version reports: shared-category preservation, unavailable-category fallback, save/reopen persistence, and changing the bare project URL headline from 49.31% to 70.49% and back to All. Visually checked the rendered selector. Production GitHub OAuth was not exercised.
